### PR TITLE
LHC-491 update fast track template to engage european visitors

### DIFF
--- a/theme/src/css/_zendesk-elements.scss
+++ b/theme/src/css/_zendesk-elements.scss
@@ -122,8 +122,10 @@ textarea,
 }
 
 .initiative-blurb {
+	border-left: 2px solid $color-warning-border;
 	font-style: italic;
-	padding: 3rem 0;
+	margin: 1.5rem 0 3rem;
+	padding-left: $padding-default;
 
 	.leading-text {
 		color: $color-warning;

--- a/theme/src/css/_zendesk-variables.scss
+++ b/theme/src/css/_zendesk-variables.scss
@@ -21,6 +21,7 @@ $color-primary-focus-border: #71A2FF !default;
 $color-primary-hover: #0053F0 !default;
 $color-success: #287D3C !default;
 $color-warning-background: #FFF4EC !default;
+$color-warning-border: #FF8F39 !default;
 $color-warning: #B95000 !default;
 
 $color-grey: #F5F7FA !default;

--- a/theme/src/resources/templates/article_pages/fast_track.hbs
+++ b/theme/src/resources/templates/article_pages/fast_track.hbs
@@ -5,10 +5,6 @@
 		</div>
 	</div>
 
-	<span class="initiative-label label label-sm" title="{{dc 'article-fast_track'}}">
-		{{dc 'article-fast_track'}}
-	</span>
-
 	{{#with article}}
 		<div class="row">
 			<h1 class="article-title col-md-7" title="{{title}}">
@@ -50,6 +46,10 @@
 					</div>
 				</div>
 
+				<aside class="initiative-blurb">
+					<span class="leading-text">{{dc 'article-fast_track'}}:</span> {{dc 'article-fast_track_disclaimer'}}
+				</aside>
+
 				<section class="article-info">
 					<div class="article-content">
 						<div class="article-body">
@@ -76,10 +76,6 @@
 						</div>
 					</div>
 				</section>
-
-				<aside class="initiative-blurb">
-					<span class="leading-text">{{dc 'article-fast_track'}}:</span> {{dc 'article-fast_track_disclaimer'}}
-				</aside>
 
 				<footer class="article-footer">
 					<div class="article-votes">


### PR DESCRIPTION
### Description
https://issues.liferay.com/browse/LHC-491

European readers are said to scan the entire article for the credibility of the source before engaging with the content. So the template for fast track changed to move the disclaimer to the top so that it's more salient to the user what the initiative is. 

### Checklist
- [x] Code compiles without errors.
- [x] All tests, new and existing, pass without errors.
- [x] Checked browser compatibility, especially IE11.
