### PR TITLE
LHC-189

### DIFF
--- a/theme/src/resources/templates/request_page.hbs
+++ b/theme/src/resources/templates/request_page.hbs
@@ -216,7 +216,9 @@
 							{{t 'organization'}}
 						</dt>
 						<dd>
-							{{select 'organization'}}
+							{{select 'organization' class='d-none'}}
+
+							<div id="orgNamePlaceholder"></div>
 						</dd>
 					{{/form}}
 
@@ -324,5 +326,17 @@
 		}
 
 		Liferay.hasWatcherPermission(window.HelpCenter.user.tags, {{request.id}}, toggleLargeFileAttachment);
+
+		const orgNameField = document.getElementById('request_organization_id');
+
+		let orgName = '-';
+
+		if (orgNameField && orgNameField.selectedIndex) {
+			orgName = orgNameField.options[orgNameField.selectedIndex].text;
+		}
+
+		const orgNamePlaceholder = document.getElementById('orgNamePlaceholder');
+
+		orgNamePlaceholder.innerHTML = orgName;
 	});
 </script>


### PR DESCRIPTION
### Description
https://issues.liferay.com/browse/LHC-189

Due to the way the Zendesk Customization is set, customers for a long project name are not able to view the full project name. To get around that, the team decided to grab the value from the dropdown and hide it. Then display that value separately as text. That way the text will naturally wrap and allow the customer to see the entire organization name.  