### PR TITLE
[Large File Uploader] Don't display link if no Account Entry ID present on ticket

### DIFF
--- a/large-file-uploader-app/assets/iframe.html
+++ b/large-file-uploader-app/assets/iframe.html
@@ -27,10 +27,14 @@
 									var element = document.getElementById('largeFileUploader');
 									element.innerHTML = '<a href="https://customer.liferay.com/project-details?p_p_id=com_liferay_osb_customer_account_entry_details_web_AccountEntryDetailsPortlet&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_com_liferay_osb_customer_account_entry_details_web_AccountEntryDetailsPortlet_mvcRenderCommandName=%2Fadd_ticket_attachment&_com_liferay_osb_customer_account_entry_details_web_AccountEntryDetailsPortlet_zendeskTicketId=' + data['ticket.id'] + '" target="_blank">Add Large Files over 20 MB here</a>';
 								}
-							)
+							).catch(function(error) {
+								console.log(error.toString());
+							});
 						}
 					}
-				);
+				).catch(function(error) {
+					console.log(error.toString());
+				});
 			}
 		);
 	</script>

--- a/large-file-uploader-app/assets/iframe.html
+++ b/large-file-uploader-app/assets/iframe.html
@@ -17,11 +17,18 @@
 					}
 				);
 
-				client.get('ticket.id').then(
+				client.get('ticket.customField:custom_field_360013377572').then(
 					function(data) {
-						var element = document.getElementById('largeFileUploader');
+						var accountEntryId = data['ticket.customField:custom_field_360013377572']
 
-						element.innerHTML = '<a href="https://customer.liferay.com/project-details?p_p_id=com_liferay_osb_customer_account_entry_details_web_AccountEntryDetailsPortlet&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_com_liferay_osb_customer_account_entry_details_web_AccountEntryDetailsPortlet_mvcRenderCommandName=%2Fadd_ticket_attachment&_com_liferay_osb_customer_account_entry_details_web_AccountEntryDetailsPortlet_zendeskTicketId=' + data['ticket.id'] + '" target="_blank">Add Large Files over 20 MB here</a>';
+						if( accountEntryId !== null && accountEntryId !== '' ) {
+							client.get('ticket.id').then(
+								function(data) {
+									var element = document.getElementById('largeFileUploader');
+									element.innerHTML = '<a href="https://customer.liferay.com/project-details?p_p_id=com_liferay_osb_customer_account_entry_details_web_AccountEntryDetailsPortlet&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_com_liferay_osb_customer_account_entry_details_web_AccountEntryDetailsPortlet_mvcRenderCommandName=%2Fadd_ticket_attachment&_com_liferay_osb_customer_account_entry_details_web_AccountEntryDetailsPortlet_zendeskTicketId=' + data['ticket.id'] + '" target="_blank">Add Large Files over 20 MB here</a>';
+								}
+							)
+						}
 					}
 				);
 			}

--- a/large-file-uploader-app/assets/iframe.html
+++ b/large-file-uploader-app/assets/iframe.html
@@ -27,9 +27,7 @@
 									var element = document.getElementById('largeFileUploader');
 									element.innerHTML = '<a href="https://customer.liferay.com/project-details?p_p_id=com_liferay_osb_customer_account_entry_details_web_AccountEntryDetailsPortlet&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_com_liferay_osb_customer_account_entry_details_web_AccountEntryDetailsPortlet_mvcRenderCommandName=%2Fadd_ticket_attachment&_com_liferay_osb_customer_account_entry_details_web_AccountEntryDetailsPortlet_zendeskTicketId=' + data['ticket.id'] + '" target="_blank">Add Large Files over 20 MB here</a>';
 								}
-							).catch(function(error) {
-								console.log(error.toString());
-							});
+							);
 						}
 					}
 				).catch(function(error) {

--- a/large-file-uploader-app/assets/iframe.html
+++ b/large-file-uploader-app/assets/iframe.html
@@ -21,7 +21,7 @@
 					function(data) {
 						var accountEntryId = data['ticket.customField:custom_field_360013377572']
 
-						if( accountEntryId && accountEntryId !== '' ) {
+						if (accountEntryId && accountEntryId !== '') {
 							client.get('ticket.id').then(
 								function(data) {
 									var element = document.getElementById('largeFileUploader');

--- a/large-file-uploader-app/assets/iframe.html
+++ b/large-file-uploader-app/assets/iframe.html
@@ -21,7 +21,7 @@
 					function(data) {
 						var accountEntryId = data['ticket.customField:custom_field_360013377572']
 
-						if( accountEntryId !== null && accountEntryId !== '' ) {
+						if( accountEntryId && accountEntryId !== '' ) {
 							client.get('ticket.id').then(
 								function(data) {
 									var element = document.getElementById('largeFileUploader');


### PR DESCRIPTION
### Description
In case the ticket does not have an organization (which happens often for escalated tickets), the Large File Uploader will not work, so it should not be displayed.

### Checklist
- [ ] Code compiles without errors. N/A
- [ ] Include tests for new features and functionality. N/A
- [ ] Update README/documentation, when applicable. N/A
- [ ] All tests, new and existing, pass without errors. N/A
- [x] Checked browser compatibility, especially IE11.

### Tested on:
- Windows 10 1703 (Build: 15063.0), Internet Explorer 11.540.15063.0
- Ubuntu 19.04, Chrome Version 74.0.3729.131 (Official Build) (64-bit)