### PR TITLE
[Large File Uploader] Use the same font-family as Zendesk

### DIFF
--- a/large-file-uploader-app/assets/iframe.html
+++ b/large-file-uploader-app/assets/iframe.html
@@ -1,7 +1,7 @@
 <html>
 <head>
-	<script type="text/javascript" src="https://assets.zendesk.com/apps/sdk/2.0/zaf_sdk.js"></script>
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@zendeskgarden/css-bedrock@7.0.24/dist/index.min.css">
+	<script type="text/javascript" src="https://assets.zendesk.com/apps/sdk/2.0/zaf_sdk.js"></script>
 </head>
 <body>
 	<script type="text/javascript">

--- a/large-file-uploader-app/assets/iframe.html
+++ b/large-file-uploader-app/assets/iframe.html
@@ -1,6 +1,7 @@
 <html>
 <head>
 	<script type="text/javascript" src="https://assets.zendesk.com/apps/sdk/2.0/zaf_sdk.js"></script>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@zendeskgarden/css-bedrock@7.0.24/dist/index.min.css">
 </head>
 <body>
 	<script type="text/javascript">


### PR DESCRIPTION
### Description
Large File Uploader looks a little bit odd and I wanted to fix this. First, I only wanted to use the same font-family definition that Zendesk uses, then I realized (keeping future improvements) that Zendesk Garden's Bedrock reset is more fitting for this.
What do you think, @rdai10?

### Checklist
- [ ] Code compiles without errors. N/A
- [ ] Include tests for new features and functionality. N/A
- [ ] Update README/documentation, when applicable. N/A
- [ ] All tests, new and existing, pass without errors. N/A
- [x] Checked browser compatibility, especially IE11.

Tested on:
- Windows 10 1703 (Build: 15063.0), Internet Explorer 11.540.15063.0
- Ubuntu 19.04, Chrome Version 74.0.3729.131 (Official Build) (64-bit)