### PR TITLE
LHC-397 section page heading spacing is off after typography change

### DIFF
--- a/theme/src/resources/templates/section_page.hbs
+++ b/theme/src/resources/templates/section_page.hbs
@@ -8,7 +8,7 @@
 	<section class="row section-content">
 		<div class="col-md-6">
 			{{#with section}}
-				<header class="section-heading">
+				<header class="section-name">
 					<h1 class="title">
 						{{name}}
 


### PR DESCRIPTION
### Description
Section page heading spacing is off after typography change from https://issues.liferay.com/browse/LHC-397

### Checklist
- [x] Code compiles without errors.
- [ ] Include tests for new features and functionality.
- [ ] Update README/documentation, when applicable.
- [ ] All tests, new and existing, pass without errors.
- [x] Checked browser compatibility, especially IE11.
