### PR TITLE
LHC-733 extra white space causes issue in javascript

### DIFF
--- a/theme/src/resources/templates/home_page.hbs
+++ b/theme/src/resources/templates/home_page.hbs
@@ -259,9 +259,7 @@
 				</div>
 
 				<div class="col-md-12">
-					<button class="btn btn-link toggle-overflow-topics" id="toggleOverflowTopics">
-						{{dc 'homepage-see_more'}}
-					</button>
+					<button class="btn btn-link toggle-overflow-topics" id="toggleOverflowTopics">{{dc 'homepage-see_more'}}</button>
 				</div>
 			</section>
 


### PR DESCRIPTION
### Description
When the button text is placed in new line, the ensuing `innerHtml` returned becomes `               See More          ` with extra spaces in front and behind text. When evaluated by javacript expression `toggleOverflowTopics.innerHTML === "{{dc 'homepage-see_more'}}"`, it always returns false the first time. 

### Checklist
- [ ] Code compiles without errors.
- [ ] Include tests for new features and functionality.
- [ ] Update README/documentation, when applicable.
- [ ] All tests, new and existing, pass without errors.
- [ ] Checked browser compatibility, especially IE11.
