### PR TITLE
LHC-183 Update docs article heading styling to match new parser markup

### DIFF
--- a/theme/src/css/_zendesk-article.scss
+++ b/theme/src/css/_zendesk-article.scss
@@ -48,10 +48,13 @@
 }
 
 .article-content {
-	a {
-		> h2,
-		> h3,
-		> h4 {
+	h2,
+	h3,
+	h4 {
+		margin-bottom: $margin-default;
+		margin-top: $margin-default;
+
+		a {
 			color: $color-body;
 
 			&::before {
@@ -63,13 +66,6 @@
 				visibility: hidden;
 			}
 		}
-	}
-
-	h2,
-	h3,
-	h4 {
-		margin-bottom: $margin-default;
-		margin-top: $margin-default;
 	}
 
 	code,

--- a/theme/src/resources/templates/article_pages/fast_track.hbs
+++ b/theme/src/resources/templates/article_pages/fast_track.hbs
@@ -77,7 +77,7 @@
 
 				<footer class="article-footer">
 					<div class="article-votes">
-						<span class=" small-title">{{t 'was_this_article_helpful'}}</span>
+						<span class="article-votes-question small-title">{{t 'was_this_article_helpful'}}</span>
 
 						<div class="article-votes-controls" role='radiogroup'>
 							{{vote 'up' role='radio' class='article-vote article-vote-up btn btn-md btn-outline-primary'}}


### PR DESCRIPTION
### Description
Due to the new official docs parser employed by the docs team, the markup for article headings will now be consist. As a result, Zendesk needs to be updated to accommodate the markup. 

https://issues.liferay.com/browse/LHC-183  

### Checklist
- [x] Code compiles without errors.
- [ ] Include tests for new features and functionality.
- [ ] Update README/documentation, when applicable.
- [ ] All tests, new and existing, pass without errors.
- [ ] Checked browser compatibility, especially IE11.
