### PR TITLE
LHC-837 add warning on ticket details page to point user to use large file uploader

### DIFF
--- a/theme/src/resources/templates/request_page.hbs
+++ b/theme/src/resources/templates/request_page.hbs
@@ -54,7 +54,9 @@
 											{{upload}}
 										</div>
 
-										{{dc 'ticket_view-_large_file_uploader_ticket_details'}}
+										<div class="secondary-font secondary-text-color">
+											{{dc 'ticket_view-_large_file_uploader_ticket_details'}}
+										</div>
 									{{/if}}
 								</div>
 

--- a/theme/src/resources/templates/request_page.hbs
+++ b/theme/src/resources/templates/request_page.hbs
@@ -53,6 +53,8 @@
 										<div class="comment-attachments form-field">
 											{{upload}}
 										</div>
+
+										{{dc 'ticket_view-_large_file_uploader_ticket_details'}}
 									{{/if}}
 								</div>
 


### PR DESCRIPTION
### Description
When an end user uploads a file that is larger than 20MB, there is no warning that the file is too large. The customer will see the file getting uploaded and the progress bar will go to 100% and when they try to submit the ticket, the page stays the same with no error message. 

This task adds a copy to notify the user to use large file upload. 

https://issues.liferay.com/browse/LHC-837

### Checklist
- [x] Code compiles without errors.
- [ ] Include tests for new features and functionality.
- [ ] Update README/documentation, when applicable.
- [x] All tests, new and existing, pass without errors.
- [x] Checked browser compatibility, especially IE11.
