### PR TITLE
Solve instanceGuid error

### DIFF
--- a/knowledge-capture-app/src/javascript/modules/SearchResults.js
+++ b/knowledge-capture-app/src/javascript/modules/SearchResults.js
@@ -71,6 +71,10 @@ function Result({categories, sections, result}) {
 			ticketSidebar.on('modalReady', () => {
 				modalInstance.trigger('transferModalData', result);
 			});
+			//The "modalReady" message handler is not getting the message from the dom that it's been removed. The below handles that upon the "modal.close" event
+			modalInstance.on('modal.close', function() {
+				ticketSidebar._messageHandlers.modalReady.pop();
+			});
 		} catch (e) {
 			console.error(
 				`Creating a new instance of modal threw the following error: ${e}`


### PR DESCRIPTION
### Description
This resolves the instanceGuid error when opening up modals every subsequent time after the first. The "modalReady" message handler was not getting the message from the DOM that the modal instance had been removed. implemented a function on modal.close to pop the old instance out of the _messageHandler array. 

### Checklist
- [x] Code compiles without errors.
- [x] Include tests for new features and functionality.
- [x] Update README/documentation, when applicable.
- [x] All tests, new and existing, pass without errors.
- [x] Checked browser compatibility, especially IE11.
